### PR TITLE
feat: add a bunch of fully-functional Wayland native KDE software

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,8 @@
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
         <a href="https://gitlab.gnome.org/World/gcolor3">gcolor3</a>,
         <a href="https://github.com/emersion/grim">grim</a>,
-        <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>
+        <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>,
+        <a href="https://apps.kde.org/kcolorchooser">KColorChooser</a>
       </li>
       <li class="list__item--ok">
         Compiz support:
@@ -54,6 +55,7 @@
       </li>
       <li class="list__item--ok">
         Document viewer:
+        <a href="https://apps.kde.org/okular">Okular</a>,
         <a href="https://git.pwmt.org/pwmt/zathura">zathura</a>
       </li>
       <li class="list__item--ok">
@@ -63,6 +65,7 @@
       </li>
       <li class="list__item--ok">
         File manager:
+        <a href="https://apps.kde.org/dolphin">Dolphin</a>,
         <a href="https://github.com/linuxmint/nemo">Nemo</a>,
         <a href="https://github.com/lxde/pcmanfm">PCManFM</a>
       </li>
@@ -78,6 +81,7 @@
       </li>
       <li class="list__item--ok">
         Image viewer:
+        <a href="https://apps.kde.org/gwenview">Gwenview</a>,
         <a href="https://sr.ht/~exec64/imv/">imv</a>,
         <a href="https://nomacs.org/">nomacs</a>,
         <a href="https://github.com/artemsen/swayimg">swayimg</a>
@@ -96,6 +100,7 @@
         Login manager:
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
+        <a href="https://github.com/sddm/sddm">SDDM</a>,
         <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>
       </li>
       <li class="list__item--ok">
@@ -125,6 +130,7 @@
       <li class="list__item--ok">
         Remote desktop utility:
         <a href="https://www.freerdp.com/">FreeRDP</a>,
+        <a href="https://invent.kde.org/plasma/krdp">KRdp</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>
       <li class="list__item--ok">
@@ -138,6 +144,7 @@
         <a href="https://github.com/xlmnxp/blue-recorder">Blue Recorder</a>,
         <a href="https://github.com/SeaDve/Kooha">Kooha</a>,
         <a href="https://obsproject.com">OBS Studio</a>,
+        <a href="https://apps.kde.org/spectacle">Spectacle</a>,
         <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
       </li>
       <li class="list__item--ok">
@@ -149,6 +156,7 @@
         <a href="https://flameshot.org/">Flameshot</a>,
         <a href="https://github.com/emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
         <a href="https://git.sr.ht/~whynothugo/shotman">Shotman</a>,
+        <a href="https://apps.kde.org/spectacle">Spectacle</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>
       </li>
       <li class="list__item--ok">
@@ -174,6 +182,7 @@
         <a href="https://codeberg.org/dnkl/foot/">foot</a>,
         <a href="https://github.com/Keruspe/Germinal">Germinal</a>,
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
+        <a href="https://apps.kde.org/konsole">Konsole</a>,
         <a href="https://github.com/realh/roxterm">ROXTerm</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>,
         <a href="https://terminator-gtk3.readthedocs.io/en/latest/">Terminator</a>,
@@ -199,6 +208,8 @@
       <li class="list__item--ok">
         Video player:
         <a href="https://github.com/Rafostar/clapper">Clapper</a>,
+        <a href="https://apps.kde.org/dragonplayer">Dragon Player<a>,
+        <a href="https://apps.kde.org/haruna">Haruna</a>,
         <a href="https://mpv.io">mpv</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
