### PR TITLE
Update dwl repository link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -182,7 +182,7 @@
       </li>
       <li class="list__item--ok">
         Tiling compositor:
-        <a href="https://github.com/djpohly/dwl">dwl</a>,
+        <a href="https://codeberg.org/dwl/dwl">dwl</a>,
         <a href="https://github.com/hyprwm/Hyprland">Hyprland</a>,
         <a href="https://www.qtile.org">Qtile</a>,
         <a href="https://github.com/ifreund/river">river</a>,


### PR DESCRIPTION
The repository has migrated to Codeberg.

## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
