### PR TITLE
feat: separate single and multi user remote access

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -123,7 +123,7 @@
         <a href="https://github.com/ArtsyMacaw/wlogout">wlogout</a>
       </li>
       <li class="list__item--ok">
-        Remote desktop utility:
+        Remote workstation access:
         <a href="https://www.freerdp.com/">FreeRDP</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>
@@ -234,6 +234,10 @@
         Displaylink driver for:
         <a href="https://github.com/swaywm/sway">Sway</a>/<a href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots:</a>
         <a href="https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/1823">Issue on gitlab with a possible patch</a>
+      </li>
+      <li class="list__item--ko">
+        Remote desktop server:
+        <a href="https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/issues/90">GNOME specific work in development</a>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
