### PR TITLE
Add hyprlock to screen lock tools

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -130,6 +130,7 @@
       <li class="list__item--ok">
         Screen lock tool:
         <a href="https://github.com/jovanlanik/gtklock">gtklock</a>,
+        <a href="https://github.com/hyprwm/hyprlock">hyprlock</a>,
         <a href="https://github.com/swaywm/swaylock">swaylock</a>,
         <a href="https://github.com/ifreund/waylock">Waylock</a>
       </li>


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
