### PR TITLE
feat: add niri to "Tiling compositor" section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -286,6 +286,7 @@
         Tiling compositor:
         <a href="https://codeberg.org/dwl/dwl">dwl</a>,
         <a href="https://hyprland.org">Hyprland</a>,
+        <a href="https://github.com/YaLTeR/niri">niri</a>,
         <a href="https://www.qtile.org">Qtile</a>,
         <a href="https://github.com/ifreund/river">river</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>,


### PR DESCRIPTION
## Description

Short description of the changes: add niri to "Tiling compositor" section

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
