### PR TITLE
feat: added Emote as an emoji handler

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -93,7 +93,8 @@
         <a href="https://github.com/marty-oehme/bemoji">bemoji</a>,
         <a href="https://github.com/kenshaw/wofimoji">wofimoji</a>,
         <a href="https://github.com/Zeioth/wofi-emoji">wofi-emoji</a>,
-        <a href="https://github.com/mijorus/smile">smile</a>
+        <a href="https://github.com/mijorus/smile">smile</a>,
+        <a href="https://github.com/tom-james-watson/Emote">Emote</a>
       </li>
       <li class="list__item--ok">
         File manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -89,12 +89,12 @@
       </li>
       <li class="list__item--ok">
         Emoji handlers:
-        <a href="https://github.com/fdw/rofimoji">rofimoji</a>,
         <a href="https://github.com/marty-oehme/bemoji">bemoji</a>,
-        <a href="https://github.com/kenshaw/wofimoji">wofimoji</a>,
-        <a href="https://github.com/Zeioth/wofi-emoji">wofi-emoji</a>,
+        <a href="https://github.com/tom-james-watson/Emote">Emote</a>,
+        <a href="https://github.com/fdw/rofimoji">rofimoji</a>,
         <a href="https://github.com/mijorus/smile">smile</a>,
-        <a href="https://github.com/tom-james-watson/Emote">Emote</a>
+        <a href="https://github.com/Zeioth/wofi-emoji">wofi-emoji</a>,
+        <a href="https://github.com/kenshaw/wofimoji">wofimoji</a>
       </li>
       <li class="list__item--ok">
         File manager:


### PR DESCRIPTION
## Description

Added Emote:
- https://github.com/tom-james-watson/Emote

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
