### PR TITLE
feat: displaylink driver for GNOME, KDE and Hyprland

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -353,6 +353,9 @@
       </li>
       <li class="list__item--kinda">
         Displaylink driver for:
+        <a href="https://www.gnome.org">GNOME</a>,
+        <a href="https://kde.org/plasma-desktop">KDE Plasma</a>,
+        <a href="https://hyprland.org">Hyprland</a>/<a href="https://github.com/hyprwm/aquamarine">aquamarine</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>/<a href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots:</a>
         <a href="https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/1823">Issue on gitlab with a possible patch</a>
       </li>


### PR DESCRIPTION
## Description

Updated displaylink support for GNOME, KDE and Hyprland.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
