### PR TITLE
update link for wmenu and grim

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
         <a href="https://github.com/lbonn/rofi">Rofi (lbonn's fork)</a>,
         <a href="https://github.com/philj56/tofi">Tofi</a>,
         <a href="https://ulauncher.io">Ulauncher</a>,
-        <a href="https://sr.ht/~adnano/wmenu/">wmenu</a>,
+        <a href="https://codeberg.org/adnano/wmenu">wmenu</a>,
         <a href="https://hg.sr.ht/~scoopta/wofi">Wofi</a>,
         <a href="https://github.com/l4l/yofi">yofi</a>
       </li>
@@ -43,7 +43,7 @@
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
         <a href="https://gitlab.gnome.org/World/gcolor3">gcolor3</a>,
-        <a href="https://github.com/emersion/grim">grim</a>,
+        <a href="https://git.sr.ht/~emersion/grim">grim</a>,
         <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>,
         <a href="https://apps.kde.org/kcolorchooser">KColorChooser</a>
       </li>
@@ -245,7 +245,7 @@
       <li class="list__item--ok">
         Screenshot tool:
         <a href="https://flameshot.org/">Flameshot</a>,
-        <a href="https://github.com/emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
+        <a href="https://git.sr.ht/~emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
         <a href="https://github.com/Gustash/Hyprshot">Hyprshot</a>,
         <a href="https://github.com/ksnip/ksnip">ksnip</a>,
         <a href="https://github.com/gabm/satty">Satty</a>,


### PR DESCRIPTION
## Description

Short description of the changes:
wmenu moved from sr.ht to codeber.org and grim moved from github to sr.ht. I changed links and checked if there is more broken links.

## Checklist

I have:

- [ x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
