### PR TITLE
feat: added ironbar as a status bar

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -266,6 +266,7 @@
       <li class="list__item--ok">
         Status bar:
         <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
+        <a href="https://github.com/JakeStanger/ironbar">Ironbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,
         <a href="https://github.com/Alexays/Waybar">Waybar</a>,
         <a href="https://codeberg.org/dnkl/yambar">Yambar</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -266,7 +266,7 @@
       <li class="list__item--ok">
         Status bar:
         <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
-        <a href="https://github.com/JakeStanger/ironbar">Ironbar</a>,
+        <a href="https://github.com/JakeStanger/ironbar">ironbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,
         <a href="https://github.com/Alexays/Waybar">Waybar</a>,
         <a href="https://codeberg.org/dnkl/yambar">Yambar</a>


### PR DESCRIPTION
## Description

Added ironbar:
- https://github.com/JakeStanger/ironbar

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
