### PR TITLE
feat: Add walker launcher

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,6 +21,7 @@
         <a href="https://github.com/lbonn/rofi">Rofi (lbonn's fork)</a>,
         <a href="https://github.com/philj56/tofi">Tofi</a>,
         <a href="https://ulauncher.io">Ulauncher</a>,
+        <a href="https://github.com/abenz1267/walker">walker</a>,
         <a href="https://codeberg.org/adnano/wmenu">wmenu</a>,
         <a href="https://hg.sr.ht/~scoopta/wofi">Wofi</a>,
         <a href="https://github.com/l4l/yofi">yofi</a>


### PR DESCRIPTION
## Description

Update index.html to include the walker application launcher.
- https://github.com/abenz1267/walker

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
