### PR TITLE
add Thunar, gBar and Hyprshade

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -103,12 +103,14 @@
         <a href="https://apps.gnome.org/en/Nautilus">Nautilus</a>,
         <a href="https://github.com/linuxmint/nemo">Nemo</a>,
         <a href="https://github.com/lxde/pcmanfm">PCManFM</a>,
-	<a href="https://github.com/lxqt/pcmanfm-qt">PCManFM-Qt</a>
+      	<a href="https://github.com/lxqt/pcmanfm-qt">PCManFM-Qt</a>
+        <a href="https://gitlab.xfce.org/xfce/thunar">Thunar</a>,
       </li>
       <li class="list__item--ok">
         Gamma & day/night adjustment tool:
         <a href="https://github.com/FedeDP/Clight">Clight</a>,
         <a href="https://gitlab.com/chinstrap/gammastep">Gammastep</a>,
+        <a href="https://github.com/loqusion/hyprshade">Hyprshade</a>,
         <a href="https://sr.ht/~kennylevinsen/wlsunset/">wlsunset</a>,
         <a href="https://github.com/maximbaz/wluma">wluma</a>,
         <a href="https://github.com/mischw/wl-gammactl">wl-gammactl</a>
@@ -269,6 +271,7 @@
       </li>
       <li class="list__item--ok">
         Status bar:
+        <a href="https://github.com/scorpion-26/gBar">gBar</a>,
         <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
         <a href="https://github.com/JakeStanger/ironbar">ironbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,


### PR DESCRIPTION
## Description

Added Thunar as a File manager, gBar as a Status bar and Hyprshade as a Gamma & day/night adjustment tool.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
