### PR TITLE
add havoc

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -289,6 +289,7 @@
         <a href="https://codeberg.org/dnkl/foot/">foot</a>,
         <a href="https://github.com/Keruspe/Germinal">Germinal</a>,
         <a href="https://gitlab.gnome.org/GNOME/gnome-terminal">GNOME Terminal</a>,
+        <a href="https://github.com/ii8/havoc">havoc</a>,
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://apps.kde.org/konsole">Konsole</a>,
         <a href="https://gitlab.gnome.org/chergert/ptyxis">Ptyxis</a>,


### PR DESCRIPTION
## Description

Added havoc, one of the first, if not the first, fully functional terminal native to wayland.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
