### PR TITLE
Add Atril to list of Wayland PDF viewers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,6 +77,7 @@
       </li>
       <li class="list__item--ok">
         Document viewer:
+		<a href="https://wiki.mate-desktop.org/mate-desktop/applications/atril/">Atril (part of MATE, but can be used standalone)</a>
         <a href="https://gitlab.gnome.org/GNOME/evince">Evince</a>,
         <a href="https://apps.kde.org/okular">Okular</a>,
         <a href="https://apps.gnome.org/Papers">Papers</a>,

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,7 +77,7 @@
       </li>
       <li class="list__item--ok">
         Document viewer:
-		<a href="https://wiki.mate-desktop.org/mate-desktop/applications/atril/">Atril (part of MATE, but can be used standalone)</a>
+        <a href="https://wiki.mate-desktop.org/mate-desktop/applications/atril/">Atril (part of MATE, but can be used standalone)</a>
         <a href="https://gitlab.gnome.org/GNOME/evince">Evince</a>,
         <a href="https://apps.kde.org/okular">Okular</a>,
         <a href="https://apps.gnome.org/Papers">Papers</a>,


### PR DESCRIPTION
## Description

Short description of the changes:

Add Atril. It's part of MATE, but works just fine standalone. Added a parenthetical about that, too, but I can delete it if needed.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
