### PR TITLE
feat: add hyprsunset and hyprpanel

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -112,6 +112,7 @@
         <a href="https://github.com/FedeDP/Clight">Clight</a>,
         <a href="https://gitlab.com/chinstrap/gammastep">Gammastep</a>,
         <a href="https://github.com/loqusion/hyprshade">Hyprshade</a>,
+        <a href="https://github.com/hyprwm/hyprsunset">Hyprsunset</a>,
         <a href="https://sr.ht/~kennylevinsen/wlsunset/">wlsunset</a>,
         <a href="https://github.com/maximbaz/wluma">wluma</a>,
         <a href="https://github.com/mischw/wl-gammactl">wl-gammactl</a>
@@ -274,6 +275,7 @@
         Status bar:
         <a href="https://github.com/scorpion-26/gBar">gBar</a>,
         <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
+        <a href="https://hyprpanel.com/">Hyprpanel</a>,
         <a href="https://github.com/JakeStanger/ironbar">ironbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,
 	<a href="https://github.com/LBCrion/sfwbar">sfwbar</a>,


### PR DESCRIPTION
Added hyprsunset (the official blue light filter by hyprland) and hyprpanel ( a highly customizable bar and a notification daemon).

Short description of the changes:
Added Hyprsunset to Gamma & day/ night adjustment tool and Hyprpanel to Status bar.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
