### PR TITLE
fix: add a missing comma in the `Widgets` section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -352,7 +352,7 @@
       <li class="list__item--ok">
         Widgets:
         <a href="https://github.com/Aylur/ags">ags</a>,
-        <a href="https://github.com/elkowar/eww">eww</a>
+        <a href="https://github.com/elkowar/eww">eww</a>,
         <a href="https://github.com/linkfrg/ignis">Ignis</a>
       </li>
     </ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -353,6 +353,7 @@
         Widgets:
         <a href="https://github.com/Aylur/ags">ags</a>,
         <a href="https://github.com/elkowar/eww">eww</a>
+        <a href="https://github.com/linkfrg/ignis">Ignis</a>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
## Description

Short description of the changes:

Added a missing comma in the `Widgets` section (after #53)

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
