### PR TITLE
Add Fabric Widgets

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -354,6 +354,7 @@
         Widgets:
         <a href="https://github.com/Aylur/ags">ags</a>,
         <a href="https://github.com/elkowar/eww">eww</a>,
+        <a href="https://wiki.ffpy.org/">Fabric</a>,
         <a href="https://github.com/linkfrg/ignis">Ignis</a>
       </li>
     </ul>


### PR DESCRIPTION
## Description

Short description of the changes:

I suggest to add the [Fabric](https://wiki.ffpy.org/) widgets.

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
