### PR TITLE
Update HDR Info

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -365,7 +365,7 @@
     <ul class="section__list">
       <li class="list__item--kinda">
         Color management and HDR:
-        <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol in development</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">experimental support in KDE Plasma</a>
+        <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol has been officially merged</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">experimental support in KDE Plasma</a>, <a href="https://github.com/hyprwm/Hyprland/pull/8715">mostly working in Hyprland</a>, <a href="https://phabricator.services.mozilla.com/D233252">support in programs such as Firefox in the making</a>
       </li>
       <li class="list__item--kinda">
         Global hotkeys and PTT:


### PR DESCRIPTION
## Description

Short description of the changes:
HDR was just merged into `wayland/wayland-protocol` a day ago, woohoo!

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] N/A: ~~✋ checked that my section has the correct casing ("My section", and not "My Section")~~
- [ ] N/A: ~~📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")~~
