### PR TITLE
Add nwg-dock-hyprland to docks section and Glx-Dock / Cairo-Dock

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -72,10 +72,10 @@
       </li>
       <li class="list__item--ok">
         Dock:
+	<a href="http://glx-dock.org/">Glx-Dock / Cairo-Dock</a>
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock">nwg-dock</a>,
 	<a href="https://github.com/nwg-piotr/nwg-dock-hyprland">nwg-dock-hyprland</a>,
-        <a href="http://glx-dock.org/">Glx-Dock / Cairo-Dock</a>
       </li>
       <li class="list__item--ok">
         Document viewer:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -74,6 +74,7 @@
         Dock:
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock">nwg-dock</a>,
+	<a href="https://github.com/nwg-piotr/nwg-dock-hyprland">nwg-dock-hyprland</a>,
         <a href="http://glx-dock.org/">Glx-Dock / Cairo-Dock</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description
[nwg-dock-hyprland](https://github.com/nwg-piotr/nwg-dock-hyprland) was excluded from the docks section. Glx-Dock was also not at the top of the list (Docks section was not in alphabetic order.)

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
