### PR TITLE
Added ScreenGrab 3.0

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -258,6 +258,7 @@
         <a href="https://github.com/Gustash/Hyprshot">Hyprshot</a>,
         <a href="https://github.com/ksnip/ksnip">ksnip</a>,
         <a href="https://github.com/gabm/satty">Satty</a>,
+	<a href="https://github.com/lxqt/screengrab">ScreenGrab</a>,
         <a href="https://git.sr.ht/~whynothugo/shotman">Shotman</a>,
         <a href="https://apps.kde.org/spectacle">Spectacle (KDE Plasma)</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>,


### PR DESCRIPTION
## Description

Added Screengrab as it supports Wayland now.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)

I opened this file with featherpad and noticed that there are already many tabs present. Probably because the GH web editor defaults to tabs. And yes, there's a tab here too, sorry. A PR which replaces all tabs?
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
