### PR TITLE
Minor fixes

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -59,16 +59,16 @@
         <a href="https://www.enlightenment.org">Enlightenment (experimental)</a>,
         <a href="https://www.gnome.org/">GNOME</a>,
         <a href="https://kde.org/plasma-desktop">KDE Plasma</a>,
-        <a href="https://mate-desktop.org">MATE Desktop (partial)</a>,
         <a href="https://lxqt-project.org">LXQt</a> <a href="https://github.com/lxqt/lxqt-wayland-session/">(Experimental)</a>,
+        <a href="https://mate-desktop.org">MATE Desktop (partial)</a>,
         <a href="https://github.com/linuxmint/cinnamon">Cinnamon</a> <a href="https://www.linuxmint.com/rel_virginia_whatsnew.php">(Experimental)</a>
       </li>
       <li class="list__item--ok">
         Discord clients and workarounds:
-        <a href="https://github.com/SpacingBat3/WebCord">WebCord</a>,
-        <a href="https://github.com/Vencord/Vesktop">Vesktop</a>,
         <a href="https://github.com/Colonial-Dev/WayAFK">AFK handling fix</a>,
-        <a href="https://github.com/Rush/wayland-push-to-talk-fix">Push to talk fix</a>
+        <a href="https://github.com/Rush/wayland-push-to-talk-fix">Push to talk fix</a>,
+        <a href="https://github.com/Vencord/Vesktop">Vesktop</a>,
+        <a href="https://github.com/SpacingBat3/WebCord">WebCord</a>
       </li>
       <li class="list__item--ok">
         Dock:
@@ -88,8 +88,8 @@
       <li class="list__item--ok">
         Email client (GUI):
         <a href="https://help.gnome.org/users/evolution/stable/">Evolution</a>,
-        <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>,
-        <a href="https://wiki.gnome.org/Apps/Geary">Geary</a>
+        <a href="https://wiki.gnome.org/Apps/Geary">Geary</a>,
+        <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>
       </li>
       <li class="list__item--ok">
         Emoji handlers:
@@ -106,7 +106,7 @@
         <a href="https://apps.gnome.org/en/Nautilus">Nautilus</a>,
         <a href="https://github.com/linuxmint/nemo">Nemo</a>,
         <a href="https://github.com/lxde/pcmanfm">PCManFM</a>,
-      	<a href="https://github.com/lxqt/pcmanfm-qt">PCManFM-Qt</a>
+      	<a href="https://github.com/lxqt/pcmanfm-qt">PCManFM-Qt</a>,
         <a href="https://gitlab.xfce.org/xfce/thunar">Thunar</a>
       </li>
       <li class="list__item--ok">
@@ -171,8 +171,8 @@
         <a href="https://gitlab.gnome.org/GNOME/gdm">GDM</a>,
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
-        <a href="https://github.com/sddm/sddm">SDDM</a>,
-        <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>
+        <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>,
+        <a href="https://github.com/sddm/sddm">SDDM</a>
       </li>
       <li class="list__item--ok">
         Network transparency:
@@ -187,8 +187,8 @@
       </li>
       <li class="list__item--ok">
         On-screen display:
-        <a href="https://github.com/ErikReider/SwayOSD">SwayOSD</a>,
-        <a href="https://github.com/heyjuvi/avizo">avizo</a>
+        <a href="https://github.com/heyjuvi/avizo">avizo</a>,
+        <a href="https://github.com/ErikReider/SwayOSD">SwayOSD</a>
       </li>
       <li class="list__item--ok">
         On-screen keyboard:
@@ -197,16 +197,16 @@
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:
+        <a href="https://github.com/maxwellainatchi/gnome-randr-rust">gnome-randr-rust (GNOME)</a>,
         <a href="https://sr.ht/~emersion/kanshi">kanshi</a>,
+        <a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor (KDE Plasma)</a>,
         <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>,
         <a href="https://gitlab.com/w0lff/shikane">shikane</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://github.com/atx/wlay">wlay</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
-        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>,
-        <a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor (KDE Plasma)</a>,
-        <a href="https://github.com/maxwellainatchi/gnome-randr-rust">gnome-randr-rust (GNOME)</a>
+        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
         Power menu:
@@ -254,12 +254,12 @@
       <li class="list__item--ok">
         Screenshot tool:
         <a href="https://flameshot.org/">Flameshot</a>,
-        <a href="https://git.sr.ht/~emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
         <a href="https://github.com/Gustash/Hyprshot">Hyprshot</a>,
         <a href="https://github.com/ksnip/ksnip">ksnip</a>,
         <a href="https://github.com/gabm/satty">Satty</a>,
         <a href="https://github.com/lxqt/screengrab">ScreenGrab</a>,
         <a href="https://git.sr.ht/~whynothugo/shotman">Shotman</a>,
+        <a href="https://git.sr.ht/~emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
         <a href="https://apps.kde.org/spectacle">Spectacle (KDE Plasma)</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>,
         <a href="https://github.com/qtilities/wshot/">WShot</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -55,7 +55,7 @@
       </li>
       <li class="list__item--ok">
         Desktop environment:
-	<a href="https://github.com/pop-os/cosmic-epoch">COSMIC Desktop (Alpha)</a>,
+        <a href="https://github.com/pop-os/cosmic-epoch">COSMIC Desktop (Alpha)</a>,
         <a href="https://www.enlightenment.org">Enlightenment (experimental)</a>,
         <a href="https://www.gnome.org/">GNOME</a>,
         <a href="https://kde.org/plasma-desktop">KDE Plasma</a>,
@@ -265,8 +265,8 @@
         <a href="https://github.com/qtilities/wshot/">WShot</a>
       </li>
       <li class="list__item--ok">
-	Scrolling compositor:
-	<a href="https://github.com/YaLTeR/niri/">niri</a>
+        Scrolling compositor:
+        <a href="https://github.com/YaLTeR/niri/">niri</a>
       </li>
       <li class="list__item--ok">
         Stacking compositor:


### PR DESCRIPTION
## Description
- Replace tabs with whitespaces
- Fix alphabetical ordering

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
