### PR TITLE
fix: kanshi url

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -201,7 +201,7 @@
       <li class="list__item--ok">
         Output/display configuration tool:
         <a href="https://github.com/maxwellainatchi/gnome-randr-rust">gnome-randr-rust (GNOME)</a>,
-        <a href="https://sr.ht/~emersion/kanshi">kanshi</a>,
+        <a href="https://gitlab.freedesktop.org/emersion/kanshi">kanshi</a>,
         <a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor (KDE Plasma)</a>,
         <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>,
         <a href="https://gitlab.com/w0lff/shikane">shikane</a>,


### PR DESCRIPTION
From the previous url:

> Warning: this project has moved to gitlab.freedesktop.org.
