### PR TITLE
Added new compositors, Rio terminal and waypaper

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -269,7 +269,8 @@
       </li>
       <li class="list__item--ok">
         Scrolling compositor:
-        <a href="https://github.com/YaLTeR/niri/">niri</a>
+        <a href="https://github.com/YaLTeR/niri/">niri</a>,
+        <a href="https://github.com/dawsers/scroll">scroll</a>
       </li>
       <li class="list__item--ok">
         Stacking compositor:
@@ -304,6 +305,7 @@
         <a href="https://apps.kde.org/konsole">Konsole</a>,
         <a href="https://gitlab.gnome.org/chergert/ptyxis">Ptyxis</a>,
         <a href="https://github.com/lxqt/qterminal/">QTerminal</a>,
+        <a href="https://github.com/raphamorim/rio">Rio</a>,
         <a href="https://github.com/realh/roxterm">ROXTerm</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>,
         <a href="https://terminator-gtk3.readthedocs.io/en/latest/">Terminator</a>,
@@ -312,11 +314,16 @@
       </li>
       <li class="list__item--ok">
         Tiling compositor:
+        <a href="https://github.com/project-repo/cagebreak">cagebreak</a>,
         <a href="https://codeberg.org/dwl/dwl">dwl</a>,
         <a href="https://hyprland.org">Hyprland</a>,
+        <a href="https://github.com/mahkoh/jay">Jay</a>,
+        <a href="https://github.com/miracle-wm-org/miracle-wm">miracle-wm</a>,
         <a href="https://github.com/YaLTeR/niri">niri</a>,
+        <a href="https://github.com/pinnacle-comp/pinnacle">Pinnacle</a>,
         <a href="https://www.qtile.org">Qtile</a>,
         <a href="https://github.com/ifreund/river">river</a>,
+        <a href="https://github.com/dawsers/scroll">scroll</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>,
         <a href="https://github.com/WillPower3309/swayfx">SwayFx</a>,
         <a href="https://github.com/michaelforney/velox">velox</a>,
@@ -345,6 +352,7 @@
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,
         <a href="https://github.com/Horus645/swww">swww</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
+        <a href="https://github.com/anufrievroman/waypaper">waypaper</a>,
         <a href="https://github.com/danyspin97/wpaperd">wpaperd</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description

Added new compositors (like pinnacle, scroll, cagebreak etc), Rio terminal, and waypaper.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
