### PR TITLE
Update Cairo-Dock

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -73,7 +73,7 @@
       </li>
       <li class="list__item--ok">
         Dock:
-        <a href="https://glx-dock.org/">Glx-Dock / Cairo-Dock</a>,
+        <a href="https://github.com/Cairo-Dock/cairo-dock-core">Cairo-Dock</a>,
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock">nwg-dock</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock-hyprland">nwg-dock-hyprland</a>


### PR DESCRIPTION
## Description

Cairo-Dock had a big Wayland update last week: https://www.phoronix.com/news/Cairo-Dock-3.6-Released
There is also a detailed list of Wayland support / bugs up in their wiki: https://github.com/Cairo-Dock/cairo-dock-core/wiki/Wayland-support

I removed the reference to "GLX-Dock" and also the old link, neither the project site at http://glx-dock.org/ nor the repository at https://download.tuxfamily.org/glxdock/ are still up. I linked the Cairo-Dock github page.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
