### PR TITLE
HDR in KDE Plasma it's no longer experimental

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -405,7 +405,7 @@
       <li class="list__item--kinda">
         Color management and HDR:
         <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol has been
-          officially merged</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">experimental support in KDE
+          officially merged</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">good support in KDE
           Plasma</a>, <a href="https://github.com/hyprwm/Hyprland/pull/8715">mostly working in Hyprland</a>, <a
           href="https://phabricator.services.mozilla.com/D233252">support in programs such as Firefox in the making</a>
       </li>


### PR DESCRIPTION
https://zamundaaa.github.io/wayland/2025/07/22/display-next-hackfest-2025.html#:~:text=KWin%E2%80%99s%20color%20management%20story%20is%20in%20a%20really%20good%20state

## Description

Remove experimental from HDR on KDE Plasma

## Checklist

I have:

- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)

