### PR TITLE
Add AIRCTL to Network Manager GUI section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -219,6 +219,10 @@
         <a href="https://github.com/sddm/sddm">SDDM</a>
       </li>
       <li class="list__item--ok">
+        Network Manager GUI:
+        <a href="https://github.com/pshycodr/airctl">AIRCTL (GTK4)</a>
+      </li>
+      <li class="list__item--ok">
         Network transparency:
         <a href="https://gitlab.freedesktop.org/mstoeckl/waypipe">Waypipe</a>
       </li>


### PR DESCRIPTION
issue: #101 

## Description

Short description of the changes:
Adds AIRCTL under the Network Manager GUI section.
AIRCTL is a GTK4 based graphical frontend for NetworkManager and works under Wayland.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
