### PR TITLE
fix: spelling

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,7 +42,7 @@
       </li>
       <li class="list__item--ok">
         Color management and HDR:
-        <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Wayland protoco exists</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">stable support in KDE
+        <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Wayland protocol exists</a>, <a href="https://wiki.archlinux.org/title/KDE#HDR">stable support in KDE
 						Plasma</a>, <a href="https://github.com/hyprwm/Hyprland/pull/8715">Hyprland</a>, <a href="https://wiki.archlinux.org/title/HDR#Firefox">Firefox</a>. <a href="https://wiki.archlinux.org/title/HDR">-> ArchWiki/HDR</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description

Short description of the changes: Fixed spelling (`protoco existsl` -> `protocol exists`)