### PR TITLE
Nyxt renovated their certificate with Let's encrypt

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -413,7 +413,7 @@
         <a href="https://www.chromium.org/">Chromium</a>,
         <a href="https://www.firefox.com/">Firefox</a>,
         <a href="https://luakit.github.io/">Luakit</a>,
-        <a href="https://github.com/atlas-engineer/nyxtr">Nyxt</a>,
+        <a href="https://nyxt.atlas.engineer/">Nyxt</a>,
         <a href="https://www.opera.com/">Opera</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>
       </li>


### PR DESCRIPTION
So bring back the webpage
Fixes https://github.com/gianklug/wearewaylandnow/issues/106