### PR TITLE
82 swww has been renamed to awww and moved from GitHub to codeberg

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -398,12 +398,12 @@
       </li>
       <li class="list__item--ok">
         Wallpaper manager:
+        <a href="https://codeberg.org/LGFae/awww">awww</a>,
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
         <a href="https://github.com/hyprwm/hyprpaper">hyprpaper</a>,
         <a href="https://github.com/GhostNaN/mpvpaper">MPVPaper</a>,
         <a href="https://github.com/vilhalmer/oguri">oguri</a>,
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,
-        <a href="https://github.com/LGFae/swww">swww</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/anufrievroman/waypaper">waypaper</a>,
         <a href="https://github.com/danyspin97/wpaperd">wpaperd</a>


### PR DESCRIPTION
## Description

Rename `swww` to `awww`, closes #82 

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
