### PR TITLE
Add Quickshell to widgets section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -422,7 +422,8 @@
         <a href="https://github.com/Aylur/ags">ags</a>,
         <a href="https://github.com/elkowar/eww">eww</a>,
         <a href="https://wiki.ffpy.org/">Fabric</a>,
-        <a href="https://github.com/ignis-sh/ignis">Ignis</a>
+        <a href="https://github.com/ignis-sh/ignis">Ignis</a>,
+        <a href="https://quickshell.org/">Quickshell</a>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
## Description

Add Quickshell to widgets section. This is used by some environments such as [Dank Material Shell](https://danklinux.com/) and [Noctalia](https://docs.noctalia.dev/). Closes #85 

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
