### PR TITLE
Avoid URL redirects on niri

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -314,7 +314,7 @@
       </li>
       <li class="list__item--ok">
         Scrolling compositor:
-        <a href="https://github.com/YaLTeR/niri/">niri</a>,
+        <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/dawsers/scroll">scroll</a>
       </li>
       <li class="list__item--ok">
@@ -372,7 +372,7 @@
         <a href="https://hyprland.org">Hyprland</a>,
         <a href="https://github.com/mahkoh/jay">Jay</a>,
         <a href="https://github.com/miracle-wm-org/miracle-wm">miracle-wm</a>,
-        <a href="https://github.com/YaLTeR/niri">niri</a>,
+        <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/pinnacle-comp/pinnacle">Pinnacle</a>,
         <a href="https://qtile.org">Qtile</a>,
         <a href="https://github.com/riverwm/river">river</a>,


### PR DESCRIPTION
https://github.com/gianklug/wearewaylandnow/actions/runs/22252731621

PD: Confirmed that redirects warning won't create issues by the link action checker