### PR TITLE
Add display manager: Plasma Login Manager

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -215,6 +215,7 @@
         <a href="https://gitlab.gnome.org/GNOME/gdm">GDM</a>,
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
+        <a href="https://invent.kde.org/plasma/plasma-login-manager">Plasma Login Manager</a>,
         <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>,
         <a href="https://github.com/sddm/sddm">SDDM</a>
       </li>


### PR DESCRIPTION
## Description

Add Plasma Login Manager (KDE fork and replacement of SDDM) to the login/display managers category.

[Released as part of Plasma 6.6](https://community.kde.org/Plasma/Plasma_6#System_2) on 2025-02-17.

This is already [available in Arch extra](https://archlinux.org/packages/extra/x86_64/plasma-login-manager/) and will be the [default login manager for KDE variants of Fedora starting from Fedora 44](https://fedoraproject.org/wiki/Changes/PlasmaLoginManager).

I accidentally closed https://github.com/gianklug/wearewaylandnow/pull/108 while trying to fix up my local repo's commits and branches. Re-opening with updated links and description now that things have changed a bit in the wider ecosystem.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
