### PR TITLE
Add ReFrame remote desktop.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -267,6 +267,7 @@
         <a href="https://www.freerdp.com/">FreeRDP</a>,
         <a href="https://gitlab.gnome.org/GNOME/gnome-remote-desktop">GNOME Remote Desktop</a>,
         <a href="https://invent.kde.org/plasma/krdp">KRdp</a>,
+        <a href="https://github.com/AlynxZhou/reframe">ReFrame</a>,
         <a href="https://github.com/LizardByte/Sunshine">Sunshine</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>


### PR DESCRIPTION
## Description

Add ReFrame remote desktop, which is my recent project that supports remote login with Wayland.

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
