### PR TITLE
hikari seems abandoned

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -315,12 +315,11 @@
       </li>
       <li class="list__item--ok">
         Scrolling compositor:
-        <a href="https://github.com/YaLTeR/niri/">niri</a>,
+        <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/dawsers/scroll">scroll</a>
       </li>
       <li class="list__item--ok">
         Stacking compositor:
-        <a href="https://hub.darcs.net/raichoo/hikari">hikari</a>,
         <a href="https://labwc.github.io/">labwc</a>,
         <a href="https://github.com/lirios/shell">Liri shell</a>
       </li>
@@ -373,7 +372,7 @@
         <a href="https://hyprland.org">Hyprland</a>,
         <a href="https://github.com/mahkoh/jay">Jay</a>,
         <a href="https://github.com/miracle-wm-org/miracle-wm">miracle-wm</a>,
-        <a href="https://github.com/YaLTeR/niri">niri</a>,
+        <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/pinnacle-comp/pinnacle">Pinnacle</a>,
         <a href="https://qtile.org">Qtile</a>,
         <a href="https://github.com/riverwm/river">river</a>,


### PR DESCRIPTION
Fixes #116 

2 dead sites and 2 year without activity
https://github.com/antaz/hikari

Update niri repo

## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
