### PR TITLE
fix typo

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -450,7 +450,7 @@
       <li class="list__item--kinda">
         When using the nouveau driver, it directly runs on
         <a href="https://github.com/swaywm/sway">Sway</a>/<a
-					 href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots</a>, for the Nividia driver you need to start it with <i>--unsupported-gpu</i>.
+					 href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots</a>, for the Nvidia driver you need to start it with <i>--unsupported-gpu</i>.
       </li>
     </ul>
   </section>


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
