### PR TITLE
Add new links to index.html for various tools

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -215,6 +215,7 @@
         <a href="https://gitlab.gnome.org/GNOME/gdm">GDM</a>,
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
+		<a href="https://nwg-piotr.github.io/nwg-shell/nwg-hello.html">nwg-hello</a>,
         <a href="https://invent.kde.org/plasma/plasma-login-manager">Plasma Login Manager</a>,
         <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>,
         <a href="https://github.com/sddm/sddm">SDDM</a>
@@ -268,6 +269,7 @@
         <a href="https://gitlab.gnome.org/GNOME/gnome-remote-desktop">GNOME Remote Desktop</a>,
         <a href="https://invent.kde.org/plasma/krdp">KRdp</a>,
         <a href="https://github.com/AlynxZhou/reframe">ReFrame</a>,
+		<a href="https://rustdesk.com">Rustdesk</a>,
         <a href="https://github.com/LizardByte/Sunshine">Sunshine</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>
@@ -412,11 +414,14 @@
       <li class="list__item--ok">
         Web browser:
         <a href="https://www.chromium.org/">Chromium</a>,
+		<a href="https://helium.computer">Helium</a>,
         <a href="https://www.firefox.com/">Firefox</a>,
+		<a href="https://librewolf.net">Librewolf</a>,
         <a href="https://luakit.github.io/">Luakit</a>,
         <a href="https://nyxt.atlas.engineer/">Nyxt</a>,
         <a href="https://www.opera.com/">Opera</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>
+		<a href="https://zen-browser.app">Zen</a>
       </li>
       <li class="list__item--ok">
         Widgets:


### PR DESCRIPTION
## Description

Short description of the changes:
I added a few apps I've come across, especially in the web browser category. No major changes. One or two of the apps I added may possibly not support Wayland, but they had no information to back that up, and seeing as they are modern and updated apps, they would have no reason not to support Wayland.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
