### PR TITLE
feat: add mango wm

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -318,13 +318,15 @@
       </li>
       <li class="list__item--ok">
         Scrolling compositor:
+		<a href="https://github.com/mangowm/mango">mango</a>,
         <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/dawsers/scroll">scroll</a>
       </li>
       <li class="list__item--ok">
         Stacking compositor:
         <a href="https://labwc.github.io/">labwc</a>,
-        <a href="https://github.com/lirios/shell">Liri shell</a>
+        <a href="https://github.com/lirios/shell">Liri shell</a>,
+		<a href="https://github.com/mangowm/mango">mango</a>
       </li>
       <li class="list__item--ok">
         Status bar:
@@ -374,6 +376,7 @@
         <a href="https://codeberg.org/dwl/dwl">dwl</a>,
         <a href="https://hyprland.org">Hyprland</a>,
         <a href="https://github.com/mahkoh/jay">Jay</a>,
+		<a href="https://github.com/mangowm/mango">mango</a>,
         <a href="https://github.com/miracle-wm-org/miracle-wm">miracle-wm</a>,
         <a href="https://github.com/niri-wm/niri">niri</a>,
         <a href="https://github.com/pinnacle-comp/pinnacle">Pinnacle</a>,


### PR DESCRIPTION
## Description
Add https://github.com/mangowm/mango


## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
