### PR TITLE
Fix #132 Atlas Nyxt

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -418,7 +418,7 @@
         <a href="https://www.firefox.com/">Firefox</a>,
 		<a href="https://librewolf.net">Librewolf</a>,
         <a href="https://luakit.github.io/">Luakit</a>,
-        <a href="https://nyxt.atlas.engineer/">Nyxt</a>,
+        <a href="https://github.com/atlas-engineer/nyxt">Nyxt</a>,
         <a href="https://www.opera.com/">Opera</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>
 		<a href="https://zen-browser.app">Zen</a>


### PR DESCRIPTION
Fixes #132 using the github repo instead of the broken SSL site.

Not a fan, but better than a broken site.

## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
