### PR TITLE
Add Talon Voice as being not supported

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -479,6 +479,10 @@
         <a href="https://github.com/obsproject/obs-browser/issues/279">obs-browser#279</a> and
         <a href="https://github.com/chromiumembedded/cef/issues/2804">cef#2804</a>
       </li>
+      <li class="list__item--ko">
+        <a href="https://talonvoice.com/">Talon</a> (voice input system) is not supported under Wayland, see
+        <a href="https://talonvoice.com/docs/">the Talon docs</a>
+      </li>
     </ul>
   </section>
 </main>


### PR DESCRIPTION
According to the Talon 0.4.0 docs (linked) in the changes, it works on X11, but not Wayland, as "Wayland compositors lack the APIs necessary for Talon and Wayland support is not planned"

## Description

Add Talon Voice to the list of unsupported software

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
